### PR TITLE
fix: swap -e and +e in helper function

### DIFF
--- a/data/usr/sbin/grub-install
+++ b/data/usr/sbin/grub-install
@@ -363,10 +363,10 @@ BuildGrubRamfs() {
 
     # Delete existing bootloader entries from firmware:
     log "Adding bootloader to EFI configuration..."
-    set +e
+    set -e
     efibootmgr | grep -i "$BOOTLOADER_ID" | cut -c 5-8 | xargs -n 1 -r \
 	efibootmgr --quiet --delete-bootnum --bootnum
-    set -e
+    set +e
     # Add new bootloader entry. nvme looks like /dev/nvme0n1p1
     DEVICE="$(df -T /boot/efi | sed -n 2p | awk '{ print $1}')"
     if [[ $DEVICE =~ n[0-9]+p[0-9] ]]


### PR DESCRIPTION
In a helper function we turned off exiting on error, then enabled it
after calling an external utility. This had the behavior of forcing
later calls in the script to immediately exit whenever a non-zero error
code was returned by anything. Unfortunatly, we were testing the result
of a helper function (`CheckSig`) by testing `$?`. If it was non-zero,
we'd immediately exit the program, leading to a failure to actually
generate signatures, and a failure to finish installation.

Change the code to set the flags in the correct order.